### PR TITLE
expose transport exceptions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -159,6 +159,10 @@ final class Client implements ClientInterface
                 return $event->getId();
             }
         } catch (\Throwable $exception) {
+            $this->logger->error(
+                sprintf('Failed to send the event to Sentry. Reason: "%s".', $exception->getMessage()),
+                ['exception' => $exception, 'event' => $event]
+            );
         }
 
         return null;


### PR DESCRIPTION
Rel: https://github.com/getsentry/sentry-php/pull/1322

Send transport exceptions to logger, instead of ignoring, thus allowing for the problem to be noticed and handled.

The following code in `Client.php` on [line 155](https://github.com/getsentry/sentry-php/blob/5b611e3f09035f5ad5edf494443e3236bd5ea482/src/Client.php#L155)  can throw an exception:

```php
$response = $this->transport->send($event)->wait();
```

That exception then gets swallowed by the empty `catch` block. This causes Sentry events to be discarded silently
in case of unsuccessful HTTP requests.

`HttpTransport->send()` [can return](https://github.com/getsentry/sentry-php/blob/5b611e3f09035f5ad5edf494443e3236bd5ea482/src/Transport/HttpTransport.php#L143) a `RejectedPromise`.
Calling `RejectedPromise->wait()`  [throws a](https://github.com/guzzle/promises/blob/fe752aedc9fd8fcca3fe7ad05d419d32998a06da/src/RejectedPromise.php#L64) `RejectionException`.
